### PR TITLE
Add GPG key and apt source

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,15 @@
 class newrelic_infrastructure::install {
-  # - get the gpg key
-  # - add as an available source
+  include apt
+
+  apt::source { 'newrelic_infrastructure':
+    location => 'https://download.newrelic.com/infrastructure_agent/linux/apt',
+    repos    => 'main',
+    release  => $::lsbdistcodename,
+    key      => {
+      'id'     => 'A758B3FBCD43BE8D123A3476BB29EE038ECCE87C',
+      'source' => 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+    }
+  }
 
   package { 'newrelic-infra':
     ensure => installed,

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,14 @@
   "project_page": "https://github.com/jacobbednarz/puppet-newrelic_infrastructure",
   "issues_url": "https://github.com/jacobbednarz/puppet-newrelic_infrastructure/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name":"puppetlabs-apt",
+      "version_requirement": ">= 1.0.0"
+    }
   ],
   "data_provider": null
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,5 +1,27 @@
 require 'spec_helper'
 
 describe 'newrelic_infrastructure::install' do
+  let (:facts) do
+    {
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Ubuntu',
+      :lsbdistrelease  => '14.04',
+      :puppetversion   => Puppet.version,
+      :lsbdistid       => 'Ubuntu',
+      :lsbdistcodename => 'trusty',
+    }
+  end
+
   it { should contain_package('newrelic-infra') }
+
+  it do
+    should contain_apt__source('newrelic_infrastructure').with({
+      :location => 'https://download.newrelic.com/infrastructure_agent/linux/apt',
+      :repos    => 'main',
+      :release  => 'trusty',
+      :key      => {
+        'id'     => 'A758B3FBCD43BE8D123A3476BB29EE038ECCE87C',
+        'source' => 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+      }})
+  end
 end


### PR DESCRIPTION
Updates `newrelic_infrastructure::install` to install the correct GPG
key and the apt-source so that we can get the correct package.

Fixes #1