### PR TITLE
Perform validation on license keys

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,10 @@ class newrelic_infrastructure::config(
   $license_key = ''
 ) {
 
+  if ($license_key == '') {
+    fail('License key cannot be empty.')
+  }
+
   file { '/etc/newrelic-infra.yml':
     ensure  => file,
     content => template('newrelic_infrastructure/etc/newrelic-infra.yml.erb'),

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,7 +1,15 @@
 require 'spec_helper'
 
 describe 'newrelic_infrastructure::config' do
-  it do
-    should contain_file('/etc/newrelic-infra.yml').with_content(/^license_key:\s/)
+  context 'without a license key' do
+    it { should raise_error(Puppet::ParseError, /License key cannot be empty/) }
+  end
+
+  context 'with a valid license key' do
+    let(:params) do
+      { :license_key => 'abc123' }
+    end
+
+    it { should contain_file('/etc/newrelic-infra.yml').with_content(/^license_key:\s/) }
   end
 end


### PR DESCRIPTION
You shouldn't ever have an empty license key so let's fail loudly if
you manage to forget it.